### PR TITLE
Presort scores to avoid allocations

### DIFF
--- a/browscap.go
+++ b/browscap.go
@@ -143,22 +143,20 @@ func searchIndexedBrowserData(userAgent string) (map[string]string, bool) {
 
 	sort.Sort(nonemptyLists) // shorter first
 
-	listIdx := make([]int, len(nonemptyLists))
-
+	idx := 0
 	for startI := 0; startI < len(nonemptyLists); {
-		for i := startI; i < len(listIdx); i++ {
-			idx := listIdx[i]
+		for i := startI; i < len(nonemptyLists); i++ {
 			if idx >= len(nonemptyLists[i]) {
-				startI++
+				startI++ // when we ran out of elements in the column, we can move right
 				continue
 			}
 			ee := dict.expressionList[nonemptyLists[i][idx].Key]
 			if ee.Match(agentBytes) {
-				data := dict.findData(ee.Name)
+				data := dict.getData(ee.Name)
 				return data, true
 			}
-			listIdx[i]++
 		}
+		idx++
 	}
 
 	return nil, false
@@ -189,7 +187,7 @@ func getBrowserData(prefix string, agent []byte) (map[string]string, bool) {
 	if expressions, exists := dict.expressions[prefix]; exists {
 		for _, exp := range expressions {
 			if exp.Match(agent) {
-				data := dict.findData(exp.Name)
+				data := dict.getData(exp.Name)
 				return data, true
 			}
 		}

--- a/dictionary.go
+++ b/dictionary.go
@@ -6,7 +6,7 @@ type dictionary struct {
 
 	expressionList    []*expression
 	expressionLengths []float64
-	ngramIndex        map[string][]int
+	ngramIndex        map[string]hitPairList
 }
 
 type section map[string]string
@@ -18,7 +18,7 @@ func newDictionary() *dictionary {
 
 		expressionList:    make([]*expression, 0, 0),
 		expressionLengths: make([]float64, 0, 0),
-		ngramIndex:        make(map[string][]int),
+		ngramIndex:        make(map[string]hitPairList),
 	}
 }
 

--- a/dictionary.go
+++ b/dictionary.go
@@ -7,6 +7,8 @@ type dictionary struct {
 	expressionList    []*expression
 	expressionLengths []float64
 	ngramIndex        map[string]hitPairList
+
+	completeData map[string]map[string]string
 }
 
 type section map[string]string
@@ -19,16 +21,28 @@ func newDictionary() *dictionary {
 		expressionList:    make([]*expression, 0, 0),
 		expressionLengths: make([]float64, 0, 0),
 		ngramIndex:        make(map[string]hitPairList),
+
+		completeData: make(map[string]map[string]string),
 	}
 }
 
-func (self *dictionary) findData(name string) map[string]string {
+func (self *dictionary) buildCompleteData() {
+	for name, _ := range self.mapped {
+		self.completeData[name] = self.buildData(name)
+	}
+}
+
+func (self *dictionary) getData(name string) map[string]string {
+	return self.completeData[name]
+}
+
+func (self *dictionary) buildData(name string) map[string]string {
 	res := make(map[string]string)
 
 	if item, found := self.mapped[name]; found {
 		// Parent's data
 		if parentName, hasParent := item["Parent"]; hasParent {
-			parentData := self.findData(parentName)
+			parentData := self.buildData(parentName)
 			if len(parentData) > 0 {
 				for k, v := range parentData {
 					if k == "Parent" {

--- a/loader.go
+++ b/loader.go
@@ -205,5 +205,7 @@ func loadFromIniFile(path string) (*dictionary, error) {
 		sort.Sort(sort.Reverse(l))
 	}
 
+	dict.buildCompleteData()
+
 	return dict, nil
 }

--- a/loader.go
+++ b/loader.go
@@ -146,15 +146,16 @@ func loadFromIniFile(path string) (*dictionary, error) {
 
 			// add the expression to the expression list
 			i := len(dict.expressionList)
+			score := float64(len(ee.Name))
 			dict.expressionList = append(dict.expressionList, ee)
-			dict.expressionLengths = append(dict.expressionLengths, float64(len(ee.Name)))
+			dict.expressionLengths = append(dict.expressionLengths, score)
 			for _, ngram := range getNGrams(strings.ToLower(sectionName), NGRAM_LEN) {
 				if !strings.Contains(ngram, "*") && !strings.Contains(ngram, "?") {
 					expressionIndex, found := dict.ngramIndex[ngram]
 					if !found {
-						expressionIndex = make([]int, 0, 0)
+						expressionIndex = make(hitPairList, 0, 1)
 					}
-					expressionIndex = append(expressionIndex, i)
+					expressionIndex = append(expressionIndex, hitPair{Key: i, Val: score})
 					dict.ngramIndex[ngram] = expressionIndex
 				}
 			}
@@ -198,6 +199,10 @@ func loadFromIniFile(path string) (*dictionary, error) {
 		expressions := dict.expressions[prefix]
 		sort.Sort(expressionByNameLen(expressions))
 		dict.expressions[prefix] = expressions
+	}
+
+	for _, l := range dict.ngramIndex {
+		sort.Sort(sort.Reverse(l))
 	}
 
 	return dict, nil


### PR DESCRIPTION
This change presorts scores for each ngram and then searches through them top to bottom for all selected ngrams at the same time.
The search is not strictly best to worst any more, but it avoids large allocations.

This is the benchmark comparison:
Before:
BenchmarkNoCache-4       500       3499992 ns/op      417796 B/op        360 allocs/op

After:
BenchmarkNoCache-4      1000       1417874 ns/op        5211 B/op         21 allocs/op
